### PR TITLE
Use ActivityTracker.getInstance().inc() to force update of ui

### DIFF
--- a/src/main/kotlin/no/spk/fiskeoye/plugin/actions/window/TableAction.kt
+++ b/src/main/kotlin/no/spk/fiskeoye/plugin/actions/window/TableAction.kt
@@ -1,6 +1,5 @@
 package no.spk.fiskeoye.plugin.actions.window
 
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.ui.table.JBTable
 import no.spk.fiskeoye.plugin.actions.FiskeoyeAction
@@ -13,11 +12,7 @@ internal abstract class TableAction(
 ) : FiskeoyeAction(toolTip, icon) {
 
     override fun update(e: AnActionEvent) {
-        super.update(e)
-        if (e.project == null) return
         e.presentation.isEnabled = table.rowCount > 0
     }
-
-    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
 }

--- a/src/main/kotlin/no/spk/fiskeoye/plugin/listeners/button/FileContentSearchListener.kt
+++ b/src/main/kotlin/no/spk/fiskeoye/plugin/listeners/button/FileContentSearchListener.kt
@@ -1,5 +1,6 @@
 package no.spk.fiskeoye.plugin.listeners.button
 
+import com.intellij.ide.ActivityTracker
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -91,7 +92,7 @@ internal class FileContentSearchListener(private val fileContentPanel: FileConte
                 mainTable.model = model
                 mainTable.hideColumns()
                 urlLabel.text = requestUrl
-                updateUI()
+                ActivityTracker.getInstance().inc()
             }
         }
     }

--- a/src/main/kotlin/no/spk/fiskeoye/plugin/listeners/button/FilenameSearchListener.kt
+++ b/src/main/kotlin/no/spk/fiskeoye/plugin/listeners/button/FilenameSearchListener.kt
@@ -1,5 +1,6 @@
 package no.spk.fiskeoye.plugin.listeners.button
 
+import com.intellij.ide.ActivityTracker
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import no.spk.fiskeoye.plugin.service.FiskeoyeService.getFilename
@@ -83,7 +84,7 @@ internal class FilenameSearchListener(private val filenamePanel: FilenamePanel) 
                 mainTable.model = model
                 mainTable.hideColumns()
                 urlLabel.text = requestUrl
-                updateUI()
+                ActivityTracker.getInstance().inc()
             }
         }
     }


### PR DESCRIPTION
Calling inc() after updating fileContentPanel and filenamePanel ensures that the IDE is aware of the changes and can react accordingly, such as updating the tool window or refreshing the UI.