### PR TITLE
Downgrade version of http4k

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,10 @@ jobs:
         with:
           tool-cache: true
           large-packages: true
+          android: true
+          dotnet: true
+          swap-storage: true
+          docker-images: true
 
       # Check out current repository
       - name: Fetch Sources
@@ -185,6 +189,10 @@ jobs:
         with:
           tool-cache: true
           large-packages: true
+          android: true
+          dotnet: true
+          swap-storage: true
+          docker-images: true
 
       # Check out the current repository
       - name: Fetch Sources

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     implementation("org.jsoup:jsoup:1.20.1")
-    implementation("org.http4k:http4k-core:6.11.1.0")
+    implementation("org.http4k:http4k-core:5.47.0.0")
 
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")


### PR DESCRIPTION
Need to downgrade version of http4k, as [latest](https://github.com/http4k/http4k/releases/tag/6.0.0.0) version is using newer version of java.