### PR TITLE
Fix com.intellij.platform.instanceContainer.CycleInitializationException

### DIFF
--- a/src/main/kotlin/no/spk/fiskeoye/plugin/settings/FiskeoyeState.kt
+++ b/src/main/kotlin/no/spk/fiskeoye/plugin/settings/FiskeoyeState.kt
@@ -23,7 +23,7 @@ internal class FiskeoyeState : PersistentStateComponent<FiskeoyeState> {
     internal var truncSize: Int = 3000
     internal var codeLength: Int = 400
 
-    override fun getState(): FiskeoyeState = ApplicationManager.getApplication().getService(FiskeoyeState::class.java)!!
+    override fun getState(): FiskeoyeState = ApplicationManager.getApplication().getService(FiskeoyeState::class.java) ?: this
 
     override fun loadState(state: FiskeoyeState) = XmlSerializerUtil.copyBean(state, this)
 


### PR DESCRIPTION
CycleInitializationException is been thrown the first time someone install the plugin as the file fiskeoye.xml is not created. 